### PR TITLE
Adding host key verification

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -33,7 +33,7 @@ var runCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		specData, err := specfile.ReadSpecFile(args[0])
 		if err != nil {
-			return fmt.Errorf("Unable to parse config file: %s", args[0])
+			return fmt.Errorf("Unable to parse config file '%s': %v", args[0], err)
 		}
 		writer, err := specfile.NewConsolidatedWriter(specData, os.Stdout)
 		if err != nil {

--- a/specfile/specfile.go
+++ b/specfile/specfile.go
@@ -206,13 +206,13 @@ func NewSpecTemplate(config *SpecTemplateConfig) (string, error) {
 func ReadSpecFile(filename string) (*SpecData, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Unable to read '%s': %v", filename, err)
 	}
 
 	specData := &SpecData{}
 	err = yaml.Unmarshal(data, specData)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Unable to parse YAML file '%s': %v", filename, err)
 	}
 
 	return specData, nil

--- a/specfile/specfile_test.go
+++ b/specfile/specfile_test.go
@@ -23,13 +23,13 @@ import (
 )
 
 var hostAndKeysData SpecData = SpecData{
-	map[string]HostSpec{
-		"host1": HostSpec{"remote-host-1", "", "/var/log/syslog", 22},
-		"host2": HostSpec{"remote-host-2", "me", "/var/log/syslog", 22},
+	map[string]*HostSpec{
+		"host1": &HostSpec{"remote-host-1", "", "/var/log/syslog", 22},
+		"host2": &HostSpec{"remote-host-2", "me", "/var/log/syslog", 22},
 	},
-	map[string]KeySpec{
-		"host1": KeySpec{"~/.ssh/id_rsa"},
-		"host2": KeySpec{"~/.ssh/id_rsa"},
+	map[string]*KeySpec{
+		"host1": &KeySpec{"~/.ssh/id_rsa"},
+		"host2": &KeySpec{"~/.ssh/id_rsa"},
 	},
 }
 
@@ -51,13 +51,13 @@ keys:
 `
 
 var commentHostAndKeysData SpecData = SpecData{
-	map[string]HostSpec{
-		"host1": HostSpec{"remote-host-1", "", "/var/log/syslog", 22},
-		"host2": HostSpec{"remote-host-2", "me", "/var/log/syslog", 22},
+	map[string]*HostSpec{
+		"host1": &HostSpec{"remote-host-1", "", "/var/log/syslog", 22},
+		"host2": &HostSpec{"remote-host-2", "me", "/var/log/syslog", 22},
 	},
-	map[string]KeySpec{
-		"host1": KeySpec{"~/.ssh/id_rsa"},
-		"host2": KeySpec{"~/.ssh/id_rsa"},
+	map[string]*KeySpec{
+		"host1": &KeySpec{"~/.ssh/id_rsa"},
+		"host2": &KeySpec{"~/.ssh/id_rsa"},
 	},
 }
 
@@ -85,9 +85,9 @@ keys:
 `
 
 var hostData SpecData = SpecData{
-	map[string]HostSpec{
-		"host1": HostSpec{"remote-host-1", "", "/var/log/syslog", 22},
-		"host2": HostSpec{"remote-host-2", "me", "/var/log/syslog", 22},
+	map[string]*HostSpec{
+		"host1": &HostSpec{"remote-host-1", "", "/var/log/syslog", 22},
+		"host2": &HostSpec{"remote-host-2", "me", "/var/log/syslog", 22},
 	},
 	nil,
 }
@@ -266,10 +266,10 @@ func TestValueDefaultHost(t *testing.T) {
 
 func TestDefaultKeysAdded(t *testing.T) {
 	spec := SpecData{
-		Hosts: map[string]HostSpec{
-			"host1": HostSpec{"host", "me", "file", 22},
-			"host2": HostSpec{"host", "me", "file", 22},
-			"host3": HostSpec{"host", "me", "file", 22},
+		Hosts: map[string]*HostSpec{
+			"host1": &HostSpec{"host", "me", "file", 22},
+			"host2": &HostSpec{"host", "me", "file", 22},
+			"host3": &HostSpec{"host", "me", "file", 22},
 		},
 		Keys: nil,
 	}


### PR DESCRIPTION
If the host key is not already stored in known_hosts, then the connection attempt will fail. I've made a proposal to include an interactive prompt in golang/go#40298. When that's included in the base library, I'll include it here.

Resolves #4.